### PR TITLE
Added support for cookie storage

### DIFF
--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/AMDevIT.Restling.Core.csproj
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/AMDevIT.Restling.Core.csproj
@@ -15,11 +15,9 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/AMDevIT/Restling.git</RepositoryUrl>
     <PackageTags>rest;httpclient;api;apiclient;client;restclient;restling</PackageTags>
-    <AssemblyVersion>0.2.63.0</AssemblyVersion>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>$(AssemblyVersion)</FileVersion>
-    <PackageReleaseNotes>Added additional request headers, including specific authentication header.
-Added support for per-call headers.
-Fixed minor bugs.</PackageReleaseNotes>
+    <PackageReleaseNotes>Added basic support for cookie storage and encryption.</PackageReleaseNotes>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Version>$(AssemblyVersion)</Version>

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/Cookies/HttpCookieData.cs
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/Cookies/HttpCookieData.cs
@@ -5,6 +5,7 @@
                                 string? domain = null, 
                                 string? path = null, 
                                 string? uri = null)
+        : IEquatable<HttpCookieData>, IComparable<HttpCookieData>
     {
         #region Fields
 
@@ -37,6 +38,70 @@
         {
             return $"[Domain:{this.Domain},Path:{this.path},Uri:{this.Uri}]{this.Name}={this.Value}";
         }
+
+        public override bool Equals(object? obj)
+        {
+            return Equals(obj as HttpCookieData);
+        }
+
+        public bool Equals(HttpCookieData? other)
+        {
+            if (other == null) 
+                return false;
+
+            return string.Equals(this.name, other.name, StringComparison.OrdinalIgnoreCase) &&
+                   string.Equals(this.domain, other.domain, StringComparison.OrdinalIgnoreCase) &&
+                   string.Equals(this.path, other.path, StringComparison.Ordinal) &&
+                   string.Equals(this.uri, other.uri, StringComparison.Ordinal);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(
+                this.name?.ToLowerInvariant(),
+                this.domain?.ToLowerInvariant(),
+                this.path,
+                this.uri
+            );
+        }
+
+        public int CompareTo(HttpCookieData? other)
+        {
+            if (other == null) 
+                return 1;
+
+            int nameComparison = string.Compare(this.name, other.name, StringComparison.OrdinalIgnoreCase);
+
+            if (nameComparison != 0) 
+                return nameComparison;
+
+            int domainComparison = string.Compare(this.domain, other.domain, StringComparison.OrdinalIgnoreCase);
+            if (domainComparison != 0) 
+                return domainComparison;
+
+            int pathComparison = string.Compare(this.path, other.path, StringComparison.Ordinal);
+            if (pathComparison != 0) 
+                return pathComparison;
+
+            return string.Compare(this.uri, other.uri, StringComparison.Ordinal);
+        }
+
+        #region Operators
+
+        public static bool operator ==(HttpCookieData? left, HttpCookieData? right)
+        {
+            if (left is null) 
+                return right is null;
+
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(HttpCookieData? left, HttpCookieData? right)
+        {
+            return !(left == right);
+        }
+
+        #endregion
 
         #endregion
     }

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/Cookies/Storage/CookieStorageProvider.cs
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/Cookies/Storage/CookieStorageProvider.cs
@@ -1,0 +1,132 @@
+﻿using AMDevIT.Restling.Core.Cookies.Storage.Security;
+using AMDevIT.Restling.Core.Cookies.Storage.Serialization;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using System.Net;
+
+namespace AMDevIT.Restling.Core.Cookies.Storage
+{
+    public class CookieStorageProvider(string cookieStorageFilePath,
+                                       ILogger? logger = null,
+                                       ICookieStorageProviderEncrypter? encrypter = null)
+        : ICookiesStorageProvider
+    {
+        #region Fields
+
+        private readonly ILogger? logger = logger;
+        private readonly string cookieStorageFilePath = cookieStorageFilePath;
+        private readonly ICookieStorageProviderEncrypter? encrypter = encrypter;
+        private readonly HashSet<HttpCookieData> cookies = [];
+
+        #endregion
+
+        #region Properties
+
+        public bool Encrypted
+        {
+            get;
+            set;
+        }
+
+        public string CookieStorageFilePath => this.cookieStorageFilePath;
+
+        protected ILogger? Logger => this.logger;
+
+        #endregion
+
+        #region Methods
+
+        public async Task LoadAsync(CancellationToken cancellationToken = default)
+        {
+            if (!File.Exists(this.CookieStorageFilePath))
+                throw new FileNotFoundException("Cannot find cookie storage file", this.CookieStorageFilePath);
+
+            string contentString = await File.ReadAllTextAsync(this.CookieStorageFilePath, cancellationToken);
+            if (!string.IsNullOrWhiteSpace(contentString))
+            {
+                CookieSerializationItem[] cookieSerializedItems;
+
+                if (this.Encrypted)
+                {
+                    if (this.encrypter == null)
+                        throw new InvalidOperationException("Cannot decrypt the cookie storage content without a valid encrypter");
+
+                    contentString = await this.encrypter.DecryptAsync(contentString, cancellationToken);
+                }
+                // Deserialize the content string to a list of HttpCookieData instances
+                // and store them in the internal collection
+
+                cookieSerializedItems = JsonConvert.DeserializeObject<CookieSerializationItem[]>(contentString) ?? [];
+                foreach (CookieSerializationItem cookieSerializedItem in cookieSerializedItems)
+                {
+                    bool result;
+                    HttpCookieData cookie = cookieSerializedItem.ToCookieData();
+                    result = await this.AddCookieAsync(cookie, cancellationToken);
+                    this.Logger?.LogTrace("Add cookie {cookie} to storage result: {result}", cookie, result);
+                }
+            }
+            else
+            {
+                this.Logger?.LogInformation("The cookie storage file is empty");
+            }
+        }
+        public async Task SaveAsync(CancellationToken cancellationToken = default)
+        {
+            string contentString;
+            List<CookieSerializationItem> cookieSerializedItems = [];
+
+            foreach(HttpCookieData cookie in this.cookies)
+            {
+                CookieSerializationItem cookieSerializationItem = cookie.ToSerializationItem();
+                cookieSerializedItems.Add(cookieSerializationItem);
+            }
+
+            contentString = JsonConvert.SerializeObject(cookieSerializedItems);
+
+            if (this.Encrypted == true)
+            {
+                if (this.encrypter == null)
+                    throw new InvalidOperationException("Cannot encrypt the cookie storage content without a valid encrypter");
+                contentString = await this.encrypter.EncryptAsync(contentString, cancellationToken);
+            }
+
+            using StreamWriter fileWriter = File.CreateText(this.CookieStorageFilePath);
+            await fileWriter.WriteAsync(contentString.AsMemory(), cancellationToken);
+        }
+
+        public Task<bool> AddCookieAsync(HttpCookieData cookie, CancellationToken cancellationToken = default)
+        {
+            if (this.cookies.TryGetValue(cookie, out HttpCookieData? existingCookie))
+            {
+                this.cookies.Remove(existingCookie);
+            }
+            this.cookies.Add(cookie);
+            return Task<bool>.FromResult(true);
+        }
+
+        public Task<bool> RemoveCookieAsync(HttpCookieData cookie, CancellationToken cancellationToken = default)
+        {
+            if (this.cookies.TryGetValue(cookie, out HttpCookieData? existingCookie))
+            {
+                this.cookies.Remove(existingCookie);
+                return Task<bool>.FromResult(true);
+            }
+            return Task<bool>.FromResult(false);
+        }
+
+        public CookieContainer BuildCookieContainer()
+        {
+            CookieContainer cookieContainer = new ();
+
+            foreach (HttpCookieData cookie in this.cookies)
+            {
+                Cookie newCookie = new Cookie(cookie.Name, cookie.Value, cookie.Path, cookie.Domain);
+                cookieContainer.Add(newCookie);
+            }
+
+            return cookieContainer;
+        }
+
+        #endregion
+    }
+}

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/Cookies/Storage/ICookiesStorageProvider.cs
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/Cookies/Storage/ICookiesStorageProvider.cs
@@ -1,0 +1,30 @@
+﻿using System.Net;
+
+namespace AMDevIT.Restling.Core.Cookies.Storage
+{
+    internal interface ICookiesStorageProvider
+    {
+        #region Properties
+        
+        bool Encrypted
+        {
+            get;
+        }
+
+        #endregion
+
+        #region Methods
+
+        public Task LoadAsync(CancellationToken cancellationToken = default);
+        public Task SaveAsync(CancellationToken cancellationToken = default);
+
+        
+        public Task<bool> AddCookieAsync(HttpCookieData cookie, CancellationToken cancellationToken = default);
+        public Task<bool> RemoveCookieAsync(HttpCookieData cookie, CancellationToken cancellationToken = default);
+
+        public CookieContainer BuildCookieContainer();
+
+
+        #endregion
+    }
+}

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/Cookies/Storage/Security/ICookieStorageProviderEncrypter.cs
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/Cookies/Storage/Security/ICookieStorageProviderEncrypter.cs
@@ -1,0 +1,12 @@
+﻿namespace AMDevIT.Restling.Core.Cookies.Storage.Security
+{
+    public interface ICookieStorageProviderEncrypter
+    {
+        #region Methods
+        Task<string> EncryptAsync(string text, CancellationToken cancellationToken = default);
+
+        Task<string> DecryptAsync(string encryptedText, CancellationToken cancellationToken = default);        
+
+        #endregion
+    }
+}

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/Cookies/Storage/Serialization/CookieSerializationItem.cs
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/Cookies/Storage/Serialization/CookieSerializationItem.cs
@@ -1,0 +1,78 @@
+﻿using Newtonsoft.Json;
+
+namespace AMDevIT.Restling.Core.Cookies.Storage.Serialization
+{
+    [JsonObject]
+    public class CookieSerializationItem
+    {
+        #region Properties
+
+        [JsonProperty("domain")]
+        public string? Domain
+        {
+            get;
+            set;
+        }
+
+        [JsonProperty("path")]
+        public string? Path
+        {
+            get;
+            set;
+        }
+
+        [JsonProperty("uri")]
+        public string? Uri
+        {
+            get;
+            set;
+        }
+
+        [JsonProperty("name")]
+        public string Name
+        {
+            get;
+            set;
+        } = null!;
+
+        [JsonProperty("value")]
+        public string? Value
+        {
+            get;
+            set;
+        }
+
+        #endregion
+
+        #region .ctor
+
+        public CookieSerializationItem()
+        {
+
+        }
+
+        public CookieSerializationItem(string? domain, 
+                                    string? path, 
+                                    string? uri, 
+                                    string name, 
+                                    string? value)
+        {
+            this.Domain = domain;
+            this.Path = path;
+            this.Uri = uri;
+            this.Name = name;
+            this.Value = value;
+        }
+
+        #endregion
+
+        #region Methods
+
+        public override string ToString()
+        {
+            return $"[Domain:{this.Domain},Path:{this.Path},Uri:{this.Uri}]{this.Name}={this.Value}";
+        }
+
+        #endregion
+    }
+}

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/Cookies/Storage/Serialization/SerializationExtensions.cs
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/Cookies/Storage/Serialization/SerializationExtensions.cs
@@ -1,0 +1,19 @@
+﻿namespace AMDevIT.Restling.Core.Cookies.Storage.Serialization
+{
+    public static class SerializationExtensions
+    {
+        #region Methods
+
+        public static HttpCookieData ToCookieData(this CookieSerializationItem source)
+        {
+            return new HttpCookieData(source.Name, source.Value, source.Domain, source.Path, source.Uri);
+        }
+
+        public static CookieSerializationItem ToSerializationItem(this HttpCookieData source)
+        {
+            return new CookieSerializationItem(source.Domain, source.Path, source.Uri, source.Name, source.Value);
+        }
+
+        #endregion
+    }
+}

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/RestlingClient.cs
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/RestlingClient.cs
@@ -594,7 +594,16 @@ namespace AMDevIT.Restling.Core
             ArgumentNullException.ThrowIfNull(restRequest, nameof(restRequest));
             ArgumentException.ThrowIfNullOrWhiteSpace(restRequest.Uri, nameof(restRequest.Uri));
 
+
+/* Modifica senza merge dal progetto 'AMDevIT.Restling.Core (net8.0)'
+Prima:
             httpRequest = this.BuildHttpRequestMessage(restRequest);                   
+            restRequestResult = await this.ExecuteRequestInternalAsync(restRequest, httpRequest, cancellationToken);
+Dopo:
+            httpRequest = BuildHttpRequestMessage(restRequest);                   
+            restRequestResult = await this.ExecuteRequestInternalAsync(restRequest, httpRequest, cancellationToken);
+*/
+            httpRequest = RestlingClient.BuildHttpRequestMessage(restRequest);                   
             restRequestResult = await this.ExecuteRequestInternalAsync(restRequest, httpRequest, cancellationToken);
             return restRequestResult;
         }
@@ -619,7 +628,16 @@ namespace AMDevIT.Restling.Core
             ArgumentNullException.ThrowIfNull(restRequest, nameof(restRequest));
             ArgumentException.ThrowIfNullOrWhiteSpace(restRequest.Uri, nameof(restRequest.Uri));
 
+
+/* Modifica senza merge dal progetto 'AMDevIT.Restling.Core (net8.0)'
+Prima:
             httpRequest = this.BuildHttpRequestMessage(restRequest);           
+            restRequestResult = await this.ExecuteRequestInternalAsync<T>(restRequest, httpRequest, cancellationToken);
+Dopo:
+            httpRequest = BuildHttpRequestMessage(restRequest);           
+            restRequestResult = await this.ExecuteRequestInternalAsync<T>(restRequest, httpRequest, cancellationToken);
+*/
+            httpRequest = RestlingClient.BuildHttpRequestMessage(restRequest);           
             restRequestResult = await this.ExecuteRequestInternalAsync<T>(restRequest, httpRequest, cancellationToken);
             return restRequestResult;
         }
@@ -758,7 +776,7 @@ namespace AMDevIT.Restling.Core
             return content;
         }
 
-        protected HttpRequestMessage BuildHttpRequestMessage(RestRequest restRequest)
+        protected static HttpRequestMessage BuildHttpRequestMessage(RestRequest restRequest)
         {
             HttpRequestMessage httpRequest;
             NetHttpMethod requestHttpMethod;


### PR DESCRIPTION
Added interaces for cookie storage and a default implementation. It can load, save and manipulate collection. Event if not attached to the Restling client, it's usable as it produces a valid CookieContainer instance.

closes #3 
closes #4 