### PR TITLE
Add IsSecure to HttpCookieData for compatibility

### DIFF
--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/AMDevIT.Restling.Core.csproj
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/AMDevIT.Restling.Core.csproj
@@ -15,9 +15,10 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/AMDevIT/Restling.git</RepositoryUrl>
     <PackageTags>rest;httpclient;api;apiclient;client;restclient;restling</PackageTags>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <AssemblyVersion>1.0.4.0</AssemblyVersion>
     <FileVersion>$(AssemblyVersion)</FileVersion>
-    <PackageReleaseNotes>Added basic support for cookie storage and encryption.</PackageReleaseNotes>
+    <PackageReleaseNotes>Added IsSecure boolean value to HttpCookieData, for compatibility with controls like WebView2.
+</PackageReleaseNotes>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Version>$(AssemblyVersion)</Version>

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/Cookies/HttpCookieData.cs
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/Cookies/HttpCookieData.cs
@@ -3,7 +3,8 @@
     public class HttpCookieData(string name,
                                 string? value,
                                 string? domain = null, 
-                                string? path = null, 
+                                string? path = null,
+                                bool? isSecure,
                                 string? uri = null)
         : IEquatable<HttpCookieData>, IComparable<HttpCookieData>
     {
@@ -13,6 +14,7 @@
         private readonly string? path = path;
         private readonly string? uri = uri;
         private readonly string name = name;
+        private readonly bool? isSecure = isSecure;
 
         private string? value = value;
 
@@ -23,6 +25,7 @@
         public string? Domain => this.domain;
         public string? Path => this.path;
         public string? Uri => this.uri;
+        public bool? IsSecure => this.isSecure;
         public string Name => this.name;
         public string? Value
         {
@@ -30,13 +33,15 @@
             set => this.value = value;
         }
 
+        
+
         #endregion
 
         #region Methods
 
         public override string ToString()
         {
-            return $"[Domain:{this.Domain},Path:{this.path},Uri:{this.Uri}]{this.Name}={this.Value}";
+            return $"[Domain:{this.Domain},Path:{this.path},Uri:{this.Uri}, IsSecure:{this.IsSecure}]{this.Name}={this.Value}";
         }
 
         public override bool Equals(object? obj)
@@ -46,13 +51,17 @@
 
         public bool Equals(HttpCookieData? other)
         {
+            if (ReferenceEquals(this, other)) 
+                return true;
+
             if (other == null) 
                 return false;
 
             return string.Equals(this.name, other.name, StringComparison.OrdinalIgnoreCase) &&
                    string.Equals(this.domain, other.domain, StringComparison.OrdinalIgnoreCase) &&
                    string.Equals(this.path, other.path, StringComparison.Ordinal) &&
-                   string.Equals(this.uri, other.uri, StringComparison.Ordinal);
+                   string.Equals(this.uri, other.uri, StringComparison.Ordinal) &&
+                   bool.Equals(this.isSecure, other.isSecure);
         }
 
         public override int GetHashCode()
@@ -61,7 +70,8 @@
                 this.name?.ToLowerInvariant(),
                 this.domain?.ToLowerInvariant(),
                 this.path,
-                this.uri
+                this.uri,
+                this.isSecure.GetValueOrDefault()
             );
         }
 
@@ -82,6 +92,11 @@
             int pathComparison = string.Compare(this.path, other.path, StringComparison.Ordinal);
             if (pathComparison != 0) 
                 return pathComparison;
+
+            int isSecureComparison = (this.isSecure ?? false).CompareTo(other.isSecure ?? false);
+            if (isSecureComparison != 0) 
+                return isSecureComparison;
+
 
             return string.Compare(this.uri, other.uri, StringComparison.Ordinal);
         }

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/Cookies/HttpCookieData.cs
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/Cookies/HttpCookieData.cs
@@ -4,7 +4,7 @@
                                 string? value,
                                 string? domain = null, 
                                 string? path = null,
-                                bool? isSecure,
+                                bool? isSecure = null,
                                 string? uri = null)
         : IEquatable<HttpCookieData>, IComparable<HttpCookieData>
     {

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/Cookies/Storage/Serialization/CookieSerializationItem.cs
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/Cookies/Storage/Serialization/CookieSerializationItem.cs
@@ -28,6 +28,13 @@ namespace AMDevIT.Restling.Core.Cookies.Storage.Serialization
             set;
         }
 
+        [JsonProperty("isSecure")]
+        public bool? IsSecure
+        {
+            get;
+            set;
+        }
+
         [JsonProperty("name")]
         public string Name
         {
@@ -52,14 +59,16 @@ namespace AMDevIT.Restling.Core.Cookies.Storage.Serialization
         }
 
         public CookieSerializationItem(string? domain, 
-                                    string? path, 
-                                    string? uri, 
-                                    string name, 
-                                    string? value)
+                                       string? path, 
+                                       string? uri, 
+                                       bool? isSecure, 
+                                       string name, 
+                                       string? value)
         {
             this.Domain = domain;
             this.Path = path;
             this.Uri = uri;
+            this.IsSecure = isSecure;
             this.Name = name;
             this.Value = value;
         }
@@ -70,7 +79,7 @@ namespace AMDevIT.Restling.Core.Cookies.Storage.Serialization
 
         public override string ToString()
         {
-            return $"[Domain:{this.Domain},Path:{this.Path},Uri:{this.Uri}]{this.Name}={this.Value}";
+            return $"[Domain:{this.Domain},Path:{this.Path},Uri:{this.Uri}, IsSecure: {this.IsSecure}]{this.Name}={this.Value}";
         }
 
         #endregion

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/Cookies/Storage/Serialization/SerializationExtensions.cs
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/Cookies/Storage/Serialization/SerializationExtensions.cs
@@ -6,12 +6,12 @@
 
         public static HttpCookieData ToCookieData(this CookieSerializationItem source)
         {
-            return new HttpCookieData(source.Name, source.Value, source.Domain, source.Path, source.Uri);
+            return new HttpCookieData(source.Name, source.Value, source.Domain, source.Path, source.IsSecure, source.Uri);
         }
 
         public static CookieSerializationItem ToSerializationItem(this HttpCookieData source)
         {
-            return new CookieSerializationItem(source.Domain, source.Path, source.Uri, source.Name, source.Value);
+            return new CookieSerializationItem(source.Domain, source.Path, source.Uri, source.IsSecure, source.Name, source.Value);
         }
 
         #endregion


### PR DESCRIPTION
Added IsSecure boolean property to HttpCookieData to allow Cookies from controls like WebView2 to be imported.

closes #7 