### PR TITLE
Passed unit test

### DIFF
--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/Network/Builders/Security/Headers/BasicAuthenticationBuilder.cs
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/Network/Builders/Security/Headers/BasicAuthenticationBuilder.cs
@@ -154,7 +154,7 @@ namespace AMDevIT.Restling.Core.Network.Builders.Security.Headers
                 throw new InvalidOperationException("Password is required");
 
             string headerParamsBase64;
-            byte[]? passwordBytes = password.Length > 0 ? password.ToByteArray() : [];
+            byte[]? passwordBytes = password.Length > 0 ? password.ToUtf8ByteArray() : [];
             byte[] userBytes = Encoding.UTF8.GetBytes(user);
             byte[] headerParamsBytes = new byte[userBytes.Length + 1 + passwordBytes.Length];
 

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/Security/SecureStringExtensions.cs
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/Security/SecureStringExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 using System.Security;
+using System.Text;
 
 namespace AMDevIT.Restling.Core.Security
 {
@@ -56,5 +57,35 @@ namespace AMDevIT.Restling.Core.Security
 
             throw new ArgumentNullException(nameof(secureString));
         }
+
+        internal static byte[] ToUtf8ByteArray(this SecureString secureString)
+        {
+            if (secureString == null)
+                throw new ArgumentNullException(nameof(secureString));
+
+            IntPtr ptr = IntPtr.Zero;
+            try
+            {
+                ptr = Marshal.SecureStringToBSTR(secureString);
+
+                // Leggiamo i byte UTF-16 (LE) direttamente in un array
+                int length = secureString.Length * 2; // UTF-16 usa 2 byte per carattere
+                byte[] utf16Bytes = new byte[length];
+                Marshal.Copy(ptr, utf16Bytes, 0, length);
+
+                // Convertiamo i byte UTF-16 in UTF-8 direttamente
+                byte[] utf8Bytes = Encoding.Convert(Encoding.Unicode, Encoding.UTF8, utf16Bytes);
+
+                // Puliamo subito i dati sensibili
+                Array.Clear(utf16Bytes, 0, utf16Bytes.Length);
+                return utf8Bytes;
+            }
+            finally
+            {
+                if (ptr != IntPtr.Zero)
+                    Marshal.ZeroFreeBSTR(ptr);
+            }
+        }
+
     }
 }


### PR DESCRIPTION
Added basic authentication builder for Authentication Header.
Using the basic authentication builder an authentication header could be build with username and password using secure string and other secure methods. 
This doesn't solve the intrisinc insecurity of the Basic Authentication, but allow the application to store username and password in a secure method inside the BasicAuthenticationBuilder instance.

Closes #16 