### PR TITLE
Added functionality for forcing serialization library

### DIFF
--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/AMDevIT.Restling.Core.csproj
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/AMDevIT.Restling.Core.csproj
@@ -15,7 +15,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/AMDevIT/Restling.git</RepositoryUrl>
     <PackageTags>rest;httpclient;api;apiclient;client;restclient;restling</PackageTags>
-    <AssemblyVersion>1.0.17.80</AssemblyVersion>
+    <AssemblyVersion>1.0.18.10</AssemblyVersion>
     <FileVersion>$(AssemblyVersion)</FileVersion>
     <PackageReleaseNotes>Added application/atom+xml mediatype for direct XML deserialization. Fixed a behavior where the default raw content isn't flagged as binary. Added the read behavior for atom+xml.
 </PackageReleaseNotes>

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/AMDevIT.Restling.Core.csproj
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/AMDevIT.Restling.Core.csproj
@@ -17,11 +17,11 @@
     <PackageTags>rest;httpclient;api;apiclient;client;restclient;restling</PackageTags>
     <AssemblyVersion>1.0.18.10</AssemblyVersion>
     <FileVersion>$(AssemblyVersion)</FileVersion>
-    <PackageReleaseNotes>Added application/atom+xml mediatype for direct XML deserialization. Fixed a behavior where the default raw content isn't flagged as binary. Added the read behavior for atom+xml.
+    <PackageReleaseNotes>Added a property used to force json serializer for the HTTP Rest call. Also, it's possibile to define the default JSON serializer for the restling client as a global property.
 </PackageReleaseNotes>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-    <Version>$(AssemblyVersion)</Version>
+    <Version>$(AssemblyVersion)-rc.1</Version>
     <PackageIcon>RestlingIcon.png</PackageIcon>
     <PackageId>Restling</PackageId>
   </PropertyGroup>

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/AMDevIT.Restling.Core.csproj
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/AMDevIT.Restling.Core.csproj
@@ -21,7 +21,7 @@
 </PackageReleaseNotes>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-    <Version>$(AssemblyVersion)-rc.1</Version>
+    <Version>$(AssemblyVersion)</Version>
     <PackageIcon>RestlingIcon.png</PackageIcon>
     <PackageId>Restling</PackageId>
   </PropertyGroup>

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/IRestlingClient.cs
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/IRestlingClient.cs
@@ -1,5 +1,6 @@
 ﻿using AMDevIT.Restling.Core.Network;
 using AMDevIT.Restling.Core.Network.Builders;
+using AMDevIT.Restling.Core.Serialization;
 
 namespace AMDevIT.Restling.Core
 {
@@ -13,6 +14,12 @@ namespace AMDevIT.Restling.Core
         public HttpClientContext ClientContext
         {
             get;
+        }
+
+        PayloadJsonSerializerLibrary SelectedDefaultSerializationLibrary
+        {
+            get;
+            set;
         }
 
         /// <summary>
@@ -50,7 +57,9 @@ namespace AMDevIT.Restling.Core
         /// <param name="uri">The request resource URI</param>
         /// <param name="cancellationToken">A valid cancellation token</param>
         /// <returns>The value returned from the remote resource</returns>
-        Task<RestRequestResult<T>> GetAsync<T>(string uri, CancellationToken cancellationToken = default);
+        Task<RestRequestResult<T>> GetAsync<T>(string uri,
+                                               PayloadJsonSerializerLibrary? forcePayloadJsonSerializerLibrary = null,
+                                               CancellationToken cancellationToken = default);
 
         Task<RestRequestResult> GetAsync(string uri,
                                          RequestHeaders requestHeaders,
@@ -58,6 +67,7 @@ namespace AMDevIT.Restling.Core
 
         Task<RestRequestResult<T>> GetAsync<T>(string uri,
                                                RequestHeaders requestHeaders,
+                                               PayloadJsonSerializerLibrary? forcePayloadJsonSerializerLibrary = null,
                                                CancellationToken cancellationToken = default);
 
         #endregion
@@ -74,6 +84,7 @@ namespace AMDevIT.Restling.Core
         /// <returns>The value returned from the remote resource</returns>
         Task<RestRequestResult> PostAsync<T>(string uri,
                                              T requestData,
+                                             PayloadJsonSerializerLibrary? forcePayloadJsonSerializerLibrary = null,
                                              CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -87,16 +98,19 @@ namespace AMDevIT.Restling.Core
         /// <returns>The value returned from the remote resource</returns>
         Task<RestRequestResult<D>> PostAsync<D, T>(string uri,
                                                    T requestData,
+                                                   PayloadJsonSerializerLibrary? forcePayloadJsonSerializerLibrary = null,
                                                    CancellationToken cancellationToken = default);
 
         Task<RestRequestResult> PostAsync<T>(string uri,
                                              T requestData,
                                              RequestHeaders requestHeaders,
+                                             PayloadJsonSerializerLibrary? forcePayloadJsonSerializerLibrary = null,
                                              CancellationToken cancellationToken = default);
 
         Task<RestRequestResult<D>> PostAsync<D, T>(string uri,
                                                    T requestData,
                                                    RequestHeaders requestHeaders,
+                                                   PayloadJsonSerializerLibrary? forcePayloadJsonSerializerLibrary = null,
                                                    CancellationToken cancellationToken = default);
 
         #endregion
@@ -105,6 +119,7 @@ namespace AMDevIT.Restling.Core
 
         Task<RestRequestResult> PutAsync<T>(string uri,
                                             T requestData,
+                                            PayloadJsonSerializerLibrary? forcePayloadJsonSerializerLibrary = null,
                                             CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -118,16 +133,19 @@ namespace AMDevIT.Restling.Core
         /// <returns>The value returned from the remote resource</returns>
         Task<RestRequestResult<D>> PutAsync<D, T>(string uri,
                                                   T requestData,
+                                                  PayloadJsonSerializerLibrary? forcePayloadJsonSerializerLibrary = null,
                                                   CancellationToken cancellationToken = default);
 
         Task<RestRequestResult> PutAsync<T>(string uri,
                                             T requestData,
                                             RequestHeaders requestHeaders,
+                                            PayloadJsonSerializerLibrary? forcePayloadJsonSerializerLibrary = null,
                                             CancellationToken cancellationToken = default);
 
         Task<RestRequestResult<D>> PutAsync<D, T>(string uri,
                                                   T requestData,
                                                   RequestHeaders requestHeaders,
+                                                  PayloadJsonSerializerLibrary? forcePayloadJsonSerializerLibrary = null,
                                                   CancellationToken cancellationToken = default);
 
         #endregion
@@ -150,7 +168,9 @@ namespace AMDevIT.Restling.Core
         /// <param name="requestData"></param>
         /// <param name="cancellationToken">A valid cancellation token</param>
         /// <returns>The value returned from the remote resource</returns>
-        Task<RestRequestResult<T>> DeleteAsync<T>(string uri, CancellationToken cancellationToken = default);
+        Task<RestRequestResult<T>> DeleteAsync<T>(string uri, 
+                                                  PayloadJsonSerializerLibrary? forcePayloadJsonSerializerLibrary = null, 
+                                                  CancellationToken cancellationToken = default);
 
         Task<RestRequestResult> DeleteAsync(string uri,
                                             RequestHeaders requestHeaders,
@@ -158,6 +178,7 @@ namespace AMDevIT.Restling.Core
 
         Task<RestRequestResult<T>> DeleteAsync<T>(string uri,
                                                   RequestHeaders requestHeaders,
+                                                  PayloadJsonSerializerLibrary? forcePayloadJsonSerializerLibrary = null,
                                                   CancellationToken cancellationToken = default);
 
         #endregion

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/RestRequest.cs
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/RestRequest.cs
@@ -1,4 +1,5 @@
 ﻿using AMDevIT.Restling.Core.Network;
+using AMDevIT.Restling.Core.Serialization;
 
 namespace AMDevIT.Restling.Core
 {
@@ -34,6 +35,15 @@ namespace AMDevIT.Restling.Core
             get => this.customMethod;
             set => this.customMethod = value;
         }
+
+        /// <summary>
+        /// Forces the selected serialization library to be used when serializing/deserializing payloads.
+        /// </summary>
+        public PayloadJsonSerializerLibrary? ForcePayloadJsonSerializerLibrary
+        {
+            get;
+            set;
+        } = null;
 
         public RequestHeaders Headers => this.headers;
 

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/RestlingClient.cs
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/RestlingClient.cs
@@ -794,6 +794,12 @@ namespace AMDevIT.Restling.Core
                     throw new InvalidOperationException("The rest request contains generic type data. Cannot be executed with using a call without payload.");
             }
 
+            restRequest.ForcePayloadJsonSerializerLibrary = this.SelectedDefaultSerializationLibrary switch
+            {
+                PayloadJsonSerializerLibrary.Automatic => restRequest.ForcePayloadJsonSerializerLibrary,
+                _ => this.SelectedDefaultSerializationLibrary
+            };
+
             try
             {
                 stopwatch = Stopwatch.StartNew();
@@ -833,6 +839,12 @@ namespace AMDevIT.Restling.Core
                 if (restRequest.GetType().IsGenericType == true)
                     throw new InvalidOperationException("The rest request contains generic type data. Cannot be executed with using a call without payload.");
             }
+
+            restRequest.ForcePayloadJsonSerializerLibrary = this.SelectedDefaultSerializationLibrary switch
+            {
+                PayloadJsonSerializerLibrary.Automatic => restRequest.ForcePayloadJsonSerializerLibrary,
+                _ => this.SelectedDefaultSerializationLibrary
+            };
 
             try
             {

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/Serialization/PayloadJsonSerializerLibrary.cs
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/Serialization/PayloadJsonSerializerLibrary.cs
@@ -1,0 +1,9 @@
+﻿namespace AMDevIT.Restling.Core.Serialization
+{
+    public enum PayloadJsonSerializerLibrary
+    {
+        Automatic,
+        NewtonsoftJson,
+        SystemTextJson
+    }
+}

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Tests/AMDevIT.Restling.Tests.csproj
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Tests/AMDevIT.Restling.Tests.csproj
@@ -18,18 +18,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="MSTest.TestAdapter" Version="3.8.1" />
+    <PackageReference Update="MSTest.TestAdapter" Version="3.8.2" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="MSTest.Analyzers" Version="3.8.1">
+    <PackageReference Update="MSTest.Analyzers" Version="3.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="MSTest.TestFramework" Version="3.8.1" />
+    <PackageReference Update="MSTest.TestFramework" Version="3.8.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Tests/Models/NS/NSArguments.cs
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Tests/Models/NS/NSArguments.cs
@@ -1,0 +1,13 @@
+﻿
+using Newtonsoft.Json;
+
+namespace AMDevIT.Restling.Tests.Models.NS
+{
+    public class NSArguments
+    {
+        [JsonIgnore]
+        [System.Text.Json.Serialization.JsonPropertyName("test")]
+        [System.Text.Json.Serialization.JsonInclude]
+        public string? Test { get; set; }
+    }
+}

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Tests/Models/NS/NSHeaders.cs
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Tests/Models/NS/NSHeaders.cs
@@ -1,0 +1,24 @@
+﻿
+using Newtonsoft.Json;
+using static Microsoft.ApplicationInsights.MetricDimensionNames.TelemetryContext;
+
+namespace AMDevIT.Restling.Tests.Models.NS
+{
+    public class NSHeaders
+    {
+        [JsonIgnore]
+        [System.Text.Json.Serialization.JsonInclude]
+        [System.Text.Json.Serialization.JsonPropertyName("Host")]
+        public string? Host { get; private set; }
+
+        [JsonIgnore]
+        [System.Text.Json.Serialization.JsonPropertyName("User - Agent")]
+        [System.Text.Json.Serialization.JsonInclude]
+        public string? UserAgent { get; private set; }
+
+        [JsonIgnore]
+        [System.Text.Json.Serialization.JsonPropertyName("X-Amzn-Trace-Id")]
+        [System.Text.Json.Serialization.JsonInclude]
+        public string? TraceId { get; private set; }
+    }
+}

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Tests/Models/NS/NSOnlyHttpBinResponse.cs
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Tests/Models/NS/NSOnlyHttpBinResponse.cs
@@ -1,0 +1,27 @@
+﻿using Newtonsoft.Json;
+
+namespace AMDevIT.Restling.Tests.Models.NS
+{
+    public class NSOnlyHttpBinResponse
+    {
+        [JsonIgnore]
+        [System.Text.Json.Serialization.JsonPropertyName("args")]
+        [System.Text.Json.Serialization.JsonInclude]
+        public NSArguments? Args { get; private set; }
+
+        [JsonIgnore]
+        [System.Text.Json.Serialization.JsonPropertyName("headers")]
+        [System.Text.Json.Serialization.JsonInclude]
+        public NSHeaders? Headers { get; private set; }
+
+        [JsonIgnore]
+        [System.Text.Json.Serialization.JsonPropertyName("origin")]
+        [System.Text.Json.Serialization.JsonInclude]
+        public string? Origin { get; private set; }
+
+        [JsonIgnore]
+        [System.Text.Json.Serialization.JsonPropertyName("url")]
+        [System.Text.Json.Serialization.JsonInclude]
+        public string? Url { get; private set; }
+    }
+}

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Tests/Models/ST/STArguments.cs
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Tests/Models/ST/STArguments.cs
@@ -1,0 +1,11 @@
+﻿using System.Text.Json.Serialization;
+
+namespace AMDevIT.Restling.Tests.Models.ST
+{
+    public class STArguments
+    {
+        [JsonPropertyName("test")]
+        [JsonInclude]
+        public string? Test { get; private set; }
+    }
+}

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Tests/Models/ST/STHeaders.cs
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Tests/Models/ST/STHeaders.cs
@@ -1,0 +1,19 @@
+﻿using System.Text.Json.Serialization;
+
+namespace AMDevIT.Restling.Tests.Models.ST
+{
+    public class STHeaders
+    {
+        [JsonPropertyName("Host")]
+        [JsonInclude]
+        public string? Host { get; private set; }
+
+        [JsonPropertyName("User-Agent")]
+        [JsonInclude]
+        public string? UserAgent { get; private set; }
+
+        [JsonPropertyName("X-Amzn-Trace-Id")]
+        [JsonInclude]
+        public string? TraceId { get; private set; }
+    }
+}

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Tests/Models/ST/STOnlyHttpBinResponse.cs
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Tests/Models/ST/STOnlyHttpBinResponse.cs
@@ -1,0 +1,23 @@
+﻿using System.Text.Json.Serialization;
+
+namespace AMDevIT.Restling.Tests.Models.ST
+{
+    public class STOnlyHttpBinResponse
+    {
+        [JsonPropertyName("args")]
+        [JsonInclude]
+        public STArguments? Args { get; private set; } 
+
+        [JsonPropertyName("headers")]
+        [JsonInclude]
+        public STHeaders? Headers { get; private set; }
+
+        [JsonPropertyName("origin")]
+        [JsonInclude]
+        public string? Origin { get; private set; }
+
+        [JsonPropertyName("url")]
+        [JsonInclude]
+        public string? Url { get; private set; }
+    }
+}

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Tests/RestClientTests.cs
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Tests/RestClientTests.cs
@@ -2,9 +2,12 @@
 using AMDevIT.Restling.Core.Network;
 using AMDevIT.Restling.Core.Network.Builders;
 using AMDevIT.Restling.Core.Network.Builders.Security.Headers;
+using AMDevIT.Restling.Core.Serialization;
 using AMDevIT.Restling.Tests.Diagnostics;
 using AMDevIT.Restling.Tests.Models;
 using AMDevIT.Restling.Tests.Models.Authentication;
+using AMDevIT.Restling.Tests.Models.NS;
+using AMDevIT.Restling.Tests.Models.ST;
 using AMDevIT.Restling.Tests.Models.Xml;
 using Microsoft.Extensions.Logging;
 using System.Diagnostics;
@@ -57,7 +60,7 @@ namespace AMDevIT.Restling.Tests
 
             uri = $"{uri}?test={parameter}";
 
-            nsRestRequestResult = await restlingClient.GetAsync<NSHttpBinResponse>(uri, cancellationToken);
+            nsRestRequestResult = await restlingClient.GetAsync<NSHttpBinResponse>(uri, cancellationToken: cancellationToken);
 
             Assert.IsNotNull(nsRestRequestResult.Data, "Rest response data for Newtonsoft is null");
 
@@ -65,7 +68,7 @@ namespace AMDevIT.Restling.Tests
             Trace.WriteLine("NS response:");
             Trace.WriteLine(nsHttpBinResponse.ToString());
 
-            stRestRequestResult = await restlingClient.GetAsync<STHttpBinResponse>(uri, cancellationToken);
+            stRestRequestResult = await restlingClient.GetAsync<STHttpBinResponse>(uri, cancellationToken: cancellationToken);
 
             Assert.IsNotNull(stRestRequestResult.Data, "Rest response data for Newtonsoft is null");
 
@@ -83,7 +86,7 @@ namespace AMDevIT.Restling.Tests
             RestRequestResult<Slideshow> restRequestResult;
             Slideshow slideshow;
 
-            restRequestResult = await restlingClient.GetAsync<Slideshow>(uri, cancellationToken);
+            restRequestResult = await restlingClient.GetAsync<Slideshow>(uri, cancellationToken: cancellationToken);
 
             Assert.IsNotNull(restRequestResult.Data, "Rest response data for Newtonsoft is null");
             Trace.WriteLine($"Request result: {restRequestResult.Content}");
@@ -103,7 +106,7 @@ namespace AMDevIT.Restling.Tests
             NSHttpBinResponse? nsHttpBinResponse;
             HttpDataTestModel testModel = new(name, surname);
 
-            nsRestRequestResult = await restlingClient.PostAsync<NSHttpBinResponse, HttpDataTestModel>(uri, testModel, cancellationToken);
+            nsRestRequestResult = await restlingClient.PostAsync<NSHttpBinResponse, HttpDataTestModel>(uri, testModel, cancellationToken: cancellationToken);
 
             Assert.IsNotNull(nsRestRequestResult.Data, "Rest response data for Newtonsoft is null");
 
@@ -123,7 +126,7 @@ namespace AMDevIT.Restling.Tests
             NSHttpBinResponse? nsHttpBinResponse;
             HttpDataTestModel testModel = new(name, surname);
 
-            nsRestRequestResult = await restlingClient.PutAsync<NSHttpBinResponse, HttpDataTestModel>(uri, testModel, cancellationToken);
+            nsRestRequestResult = await restlingClient.PutAsync<NSHttpBinResponse, HttpDataTestModel>(uri, testModel, cancellationToken: cancellationToken);
 
             Assert.IsNotNull(nsRestRequestResult.Data, "Rest response data for Newtonsoft is null");
 
@@ -147,7 +150,7 @@ namespace AMDevIT.Restling.Tests
 
             uri = $"{uri}?test={parameter}";
 
-            nsRestRequestResult = await restlingClient.DeleteAsync<NSHttpBinResponse>(uri, cancellationToken);
+            nsRestRequestResult = await restlingClient.DeleteAsync<NSHttpBinResponse>(uri, cancellationToken: cancellationToken);
 
             Assert.IsNotNull(nsRestRequestResult.Data, "Rest response data for Newtonsoft is null");
 
@@ -155,7 +158,7 @@ namespace AMDevIT.Restling.Tests
             Trace.WriteLine("NS response:");
             Trace.WriteLine(nsHttpBinResponse.ToString());
 
-            stRestRequestResult = await restlingClient.DeleteAsync<STHttpBinResponse>(uri, cancellationToken);
+            stRestRequestResult = await restlingClient.DeleteAsync<STHttpBinResponse>(uri, cancellationToken: cancellationToken);
 
             Assert.IsNotNull(stRestRequestResult.Data, "Rest response data for Newtonsoft is null");
 
@@ -187,7 +190,7 @@ namespace AMDevIT.Restling.Tests
 
             uri = $"{uri}?test={parameter}";
 
-            nsRestRequestResult = await restlingClient.GetAsync<NSHttpBinResponse>(uri, requestHeaders, cancellationToken);
+            nsRestRequestResult = await restlingClient.GetAsync<NSHttpBinResponse>(uri, requestHeaders, cancellationToken: cancellationToken);
 
             Assert.IsNotNull(nsRestRequestResult.Data, "Rest response data for Newtonsoft is null");
 
@@ -216,7 +219,7 @@ namespace AMDevIT.Restling.Tests
 
             requestHeaders.Headers.Add(additionalHeaderKey, additionalHeaderValue);            
 
-            nsRestRequestResult = await restlingClient.PostAsync<NSHttpBinResponse, HttpDataTestModel>(uri, testModel, requestHeaders, cancellationToken);
+            nsRestRequestResult = await restlingClient.PostAsync<NSHttpBinResponse, HttpDataTestModel>(uri, testModel, requestHeaders, cancellationToken: cancellationToken);
 
             Assert.IsNotNull(nsRestRequestResult.Data, "Rest response data for Newtonsoft is null");
 
@@ -245,7 +248,7 @@ namespace AMDevIT.Restling.Tests
 
             requestHeaders.Headers.Add(additionalHeaderKey, additionalHeaderValue);
 
-            nsRestRequestResult = await restlingClient.PutAsync<NSHttpBinResponse, HttpDataTestModel>(uri, testModel, requestHeaders, cancellationToken);
+            nsRestRequestResult = await restlingClient.PutAsync<NSHttpBinResponse, HttpDataTestModel>(uri, testModel, requestHeaders, cancellationToken: cancellationToken);
 
             Assert.IsNotNull(nsRestRequestResult.Data, "Rest response data for Newtonsoft is null");
 
@@ -274,7 +277,7 @@ namespace AMDevIT.Restling.Tests
 
             uri = $"{uri}?test={parameter}";
 
-            nsRestRequestResult = await restlingClient.DeleteAsync<NSHttpBinResponse>(uri, requestHeaders, cancellationToken);
+            nsRestRequestResult = await restlingClient.DeleteAsync<NSHttpBinResponse>(uri, requestHeaders, cancellationToken: cancellationToken);
 
             Assert.IsNotNull(nsRestRequestResult.Data, "Rest response data for Newtonsoft is null");
 
@@ -309,7 +312,7 @@ namespace AMDevIT.Restling.Tests
             CancellationToken cancellationToken = this.TestContext.CancellationTokenSource.Token;
             RestlingClient restlingClient = new(this.Logger);
             RestRequestResult<byte[]> restRequestResult;
-            restRequestResult = await restlingClient.GetAsync<byte[]>(uri, cancellationToken);
+            restRequestResult = await restlingClient.GetAsync<byte[]>(uri, cancellationToken: cancellationToken);
             Assert.IsTrue(restRequestResult.IsSuccessful, "Request result is not succesful");
             Assert.IsNotNull(restRequestResult.Data, "Rest response data is null");
             Trace.WriteLine(restRequestResult.ToString());            
@@ -339,10 +342,121 @@ namespace AMDevIT.Restling.Tests
             httpClientContextBuilder.AddAuthenticationHeader(authenticationHeader);
 
             restlingClient = new (httpClientContextBuilder, this.logger);
-            restRequestResult = await restlingClient.GetAsync<BasicAuthResult>(requestUri, cancellationToken);
+            restRequestResult = await restlingClient.GetAsync<BasicAuthResult>(requestUri, cancellationToken: cancellationToken);
             Assert.IsTrue(restRequestResult.IsSuccessful, $"Request result is not succesful. Result: {restRequestResult}");
             Assert.IsNotNull(restRequestResult.Data, $"Rest response data is null. Result: {restRequestResult}");
             Trace.WriteLine(restRequestResult.ToString());
+        }
+
+        #endregion
+
+        #region Forced serialization
+
+        [TestMethod]
+        [DataRow("https://httpbin.org/get", "1234")]
+        public async Task TestForcedSerializationWithWrongClassST(string uri, string parameter)
+        {
+            CancellationToken cancellationToken = this.TestContext.CancellationTokenSource.Token;
+            RestlingClient restlingClient = new(this.Logger);
+            RestRequestResult<STOnlyHttpBinResponse> stRestRequestResult;
+            STOnlyHttpBinResponse? stsHttpBinResponse;
+
+            uri = $"{uri}?test={parameter}";
+            stRestRequestResult = await restlingClient.GetAsync<STOnlyHttpBinResponse>(uri, PayloadJsonSerializerLibrary.NewtonsoftJson, cancellationToken: cancellationToken);
+
+            Assert.IsNull(stRestRequestResult.Data?.Args, "Rest response data args for Newtonsoft is still serialized even if it's decorated with System.Text.Json");
+            Assert.IsNull(stRestRequestResult.Data?.Headers, "Rest response data headers for Newtonsoft is still serialized even if it's decorated with System.Text.Json");
+            Assert.IsNull(stRestRequestResult.Data?.Url, "Rest response data url for Newtonsoft is still serialized even if it's decorated with System.Text.Json");
+
+            stRestRequestResult = await restlingClient.GetAsync<STOnlyHttpBinResponse>(uri, PayloadJsonSerializerLibrary.SystemTextJson, cancellationToken: cancellationToken);
+
+            Assert.IsNotNull(stRestRequestResult.Data?.Args, "Rest response data args for System.Text.Json is still null.");
+            Assert.IsNotNull(stRestRequestResult.Data?.Headers, "Rest response data headers for System.Text.Json is still null.");
+            Assert.IsNotNull(stRestRequestResult.Data?.Url, "Rest response data url for System.Text.Json is still null.");
+
+            Trace.WriteLine($"Request result: {stRestRequestResult.Content}");
+            stsHttpBinResponse = stRestRequestResult.Data;
+            Trace.WriteLine("STHttpBinResponse response:");
+            Trace.WriteLine(stsHttpBinResponse?.ToString());
+        }
+
+        [TestMethod]
+        [DataRow("https://httpbin.org/get", "1234")]
+        public async Task TestForcedSerializationWithDifferentSerializers(string uri, string parameter)
+        {
+            CancellationToken cancellationToken = this.TestContext.CancellationTokenSource.Token;
+            RestlingClient restlingClient = new(this.Logger);
+            RestRequestResult<NSOnlyHttpBinResponse> stRestRequestResult;
+            NSOnlyHttpBinResponse? stsHttpBinResponse;
+
+            uri = $"{uri}?test={parameter}";
+            stRestRequestResult = await restlingClient.GetAsync<NSOnlyHttpBinResponse>(uri, PayloadJsonSerializerLibrary.SystemTextJson, cancellationToken: cancellationToken);
+
+            Assert.IsNotNull(stRestRequestResult.Data?.Args, "Rest response data args for System.Text.Json is still null.");
+            Assert.IsNotNull(stRestRequestResult.Data?.Headers, "Rest response data headers for System.Text.Json is still null.");
+            Assert.IsNotNull(stRestRequestResult.Data?.Url, "Rest response data url for System.Text.Json is still null.");
+
+            stRestRequestResult = await restlingClient.GetAsync<NSOnlyHttpBinResponse>(uri, PayloadJsonSerializerLibrary.NewtonsoftJson, cancellationToken: cancellationToken);
+
+            Assert.IsNull(stRestRequestResult.Data?.Args, "Rest response data args for Newtonsoft is still serialized even if it's decorated with JsonIgnore");
+            Assert.IsNull(stRestRequestResult.Data?.Headers, "Rest response data headers for Newtonsoft is still serialized even if it's decorated with JsonIgnore");
+            Assert.IsNull(stRestRequestResult.Data?.Url, "Rest response data url for Newtonsoft is still serialized even if it's decorated with JsonIgnore");
+
+            Trace.WriteLine($"Request result: {stRestRequestResult.Content}");
+            stsHttpBinResponse = stRestRequestResult.Data;
+            Trace.WriteLine("STHttpBinResponse response:");
+            Trace.WriteLine(stsHttpBinResponse?.ToString());
+        }
+
+        [TestMethod]
+        [DataRow("https://httpbin.org/get", "1234", PayloadJsonSerializerLibrary.Automatic)]
+        [DataRow("https://httpbin.org/get", "1234", PayloadJsonSerializerLibrary.NewtonsoftJson)]
+        [DataRow("https://httpbin.org/get", "1234", PayloadJsonSerializerLibrary.SystemTextJson)]
+        public async Task TestForcedSerializationWithDifferentSerializers(string uri, string parameter, PayloadJsonSerializerLibrary serializerLibrary)
+        {
+            CancellationToken cancellationToken = this.TestContext.CancellationTokenSource.Token;
+            RestlingClient restlingClient = new(this.Logger)
+            {
+                SelectedDefaultSerializationLibrary = serializerLibrary
+            };
+
+            RestRequestResult<NSOnlyHttpBinResponse> stRestRequestResult;
+            NSOnlyHttpBinResponse? stsHttpBinResponse;
+
+            uri = $"{uri}?test={parameter}";
+
+            stRestRequestResult = await restlingClient.GetAsync<NSOnlyHttpBinResponse>(uri, cancellationToken: cancellationToken);
+
+            switch (serializerLibrary)
+            {
+                default:
+                case PayloadJsonSerializerLibrary.Automatic:
+                    {
+                        // With two serialized detected, Newtonsoft have the priority.
+
+                        Assert.IsNull(stRestRequestResult.Data?.Args, "Rest response data args for Newtonsoft is still serialized even if it's decorated with JsonIgnore");
+                        Assert.IsNull(stRestRequestResult.Data?.Headers, "Rest response data headers for Newtonsoft is still serialized even if it's decorated with JsonIgnore");
+                        Assert.IsNull(stRestRequestResult.Data?.Url, "Rest response data url for Newtonsoft is still serialized even if it's decorated with JsonIgnore");
+                    }
+                    break;
+
+                case PayloadJsonSerializerLibrary.NewtonsoftJson:
+                    Assert.IsNull(stRestRequestResult.Data?.Args, "Rest response data args for Newtonsoft is still serialized even if it's decorated with JsonIgnore");
+                    Assert.IsNull(stRestRequestResult.Data?.Headers, "Rest response data headers for Newtonsoft is still serialized even if it's decorated with JsonIgnore");
+                    Assert.IsNull(stRestRequestResult.Data?.Url, "Rest response data url for Newtonsoft is still serialized even if it's decorated with JsonIgnore");
+                    break;
+
+                case PayloadJsonSerializerLibrary.SystemTextJson:
+                    Assert.IsNotNull(stRestRequestResult.Data?.Args, "Rest response data args for System.Text.Json is still null.");
+                    Assert.IsNotNull(stRestRequestResult.Data?.Headers, "Rest response data headers for System.Text.Json is still null.");
+                    Assert.IsNotNull(stRestRequestResult.Data?.Url, "Rest response data url for System.Text.Json is still null.");
+                    break;
+            }            
+
+            Trace.WriteLine($"Request result: {stRestRequestResult.Content}");
+            stsHttpBinResponse = stRestRequestResult.Data;
+            Trace.WriteLine("STHttpBinResponse response:");
+            Trace.WriteLine(stsHttpBinResponse?.ToString());
         }
 
         #endregion


### PR DESCRIPTION
User can now force the library used to serialize and deserialize JSON, using RestRequest object or global setting in RestlingClient. 