### PR TITLE
Task raw calls

### DIFF
--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/AMDevIT.Restling.Core.csproj
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/AMDevIT.Restling.Core.csproj
@@ -21,7 +21,7 @@
 </PackageReleaseNotes>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-    <Version>$(AssemblyVersion)-alpha</Version>
+    <Version>$(AssemblyVersion)</Version>
     <PackageIcon>RestlingIcon.png</PackageIcon>
     <PackageId>Restling</PackageId>
   </PropertyGroup>

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/AMDevIT.Restling.Core.csproj
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/AMDevIT.Restling.Core.csproj
@@ -15,13 +15,13 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/AMDevIT/Restling.git</RepositoryUrl>
     <PackageTags>rest;httpclient;api;apiclient;client;restclient;restling</PackageTags>
-    <AssemblyVersion>1.0.18.10</AssemblyVersion>
+    <AssemblyVersion>1.0.19.0</AssemblyVersion>
     <FileVersion>$(AssemblyVersion)</FileVersion>
-    <PackageReleaseNotes>Added a property used to force json serializer for the HTTP Rest call. Also, it's possibile to define the default JSON serializer for the restling client as a global property.
+    <PackageReleaseNotes>Added support for raw content requests and form url encoded requests. Also changed behaviours of redirects, now Restling doesn't follow redirects automatically. 
 </PackageReleaseNotes>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-    <Version>$(AssemblyVersion)</Version>
+    <Version>$(AssemblyVersion)-alpha</Version>
     <PackageIcon>RestlingIcon.png</PackageIcon>
     <PackageId>Restling</PackageId>
   </PropertyGroup>

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/FormUrlEncodedRequest.cs
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/FormUrlEncodedRequest.cs
@@ -1,0 +1,61 @@
+﻿using AMDevIT.Restling.Core.Network;
+
+namespace AMDevIT.Restling.Core
+{
+    /// <summary>
+    /// Represents a request that will be sent as a non rest compliant form-urlencoded request.
+    /// </summary>
+    public class FormUrlEncodedRequest
+        : RestRequest
+    {
+        #region Fields
+
+        private readonly Dictionary<string, string> parameters = [];
+
+        #endregion
+
+        #region Properties
+
+        public Dictionary<string, string> Parameters => this.parameters;
+
+        #endregion
+
+        #region .ctor
+
+        public FormUrlEncodedRequest(string uri, 
+                                     HttpMethod method, 
+                                     string? customMethod = null) 
+            : base(uri, method, customMethod)
+        {
+        }
+
+        public FormUrlEncodedRequest(string uri, 
+                                     HttpMethod method, 
+                                     RequestHeaders headers, 
+                                     string? customMethod = null) 
+            : base(uri, method, headers, customMethod)
+        {
+        }
+
+        public FormUrlEncodedRequest(string uri,
+                                     HttpMethod method,
+                                     Dictionary<string, string> parameters,
+                                     string? customMethod = null)
+            : this(uri, method, customMethod)
+        {
+            this.parameters = parameters;
+        }
+
+        public FormUrlEncodedRequest(string uri,
+                                     HttpMethod method,
+                                     RequestHeaders headers,
+                                     Dictionary<string, string> parameters,
+                                     string? customMethod = null)
+            : this(uri, method, headers, customMethod)
+        {
+            this.parameters = parameters;
+        }
+
+        #endregion
+    }
+}

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/FormUrlEncodedRequest.cs
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/FormUrlEncodedRequest.cs
@@ -10,13 +10,13 @@ namespace AMDevIT.Restling.Core
     {
         #region Fields
 
-        private readonly Dictionary<string, string> parameters = [];
+        private readonly IDictionary<string, string> parameters = new Dictionary<string, string>();
 
         #endregion
 
         #region Properties
 
-        public Dictionary<string, string> Parameters => this.parameters;
+        public IDictionary<string, string> Parameters => this.parameters;
 
         #endregion
 
@@ -39,7 +39,7 @@ namespace AMDevIT.Restling.Core
 
         public FormUrlEncodedRequest(string uri,
                                      HttpMethod method,
-                                     Dictionary<string, string> parameters,
+                                     IDictionary<string, string> parameters,
                                      string? customMethod = null)
             : this(uri, method, customMethod)
         {
@@ -49,7 +49,7 @@ namespace AMDevIT.Restling.Core
         public FormUrlEncodedRequest(string uri,
                                      HttpMethod method,
                                      RequestHeaders headers,
-                                     Dictionary<string, string> parameters,
+                                     IDictionary<string, string> parameters,
                                      string? customMethod = null)
             : this(uri, method, headers, customMethod)
         {

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/HttpResponseParser.cs
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/HttpResponseParser.cs
@@ -42,10 +42,13 @@ namespace AMDevIT.Restling.Core
             {
                 byte[] rawContent;
                 RetrievedContentResult retrievedContent;
+                ResponseHeaders responseHeaders;
                 MediaTypeHeaderValue? contentType = resultHttpMessage.Content.Headers.ContentType;
                 Charset charset = CharsetParser.Parse(contentType?.CharSet);
                 rawContent = await resultHttpMessage.Content.ReadAsByteArrayAsync(cancellationToken);
                 retrievedContent = RetrieveContent(rawContent, contentType);
+                
+                responseHeaders = ResponseHeaders.Create(resultHttpMessage.Headers);
 
                 restRequestResult = new(restRequest,
                                         resultHttpMessage.StatusCode,
@@ -53,7 +56,8 @@ namespace AMDevIT.Restling.Core
                                         rawContent,
                                         contentType?.MediaType,
                                         charset,
-                                        retrievedContent);
+                                        retrievedContent,
+                                        responseHeaders);
             }
             else
             {
@@ -79,6 +83,7 @@ namespace AMDevIT.Restling.Core
                 byte[] rawContent;
                 T? data = default;
                 RetrievedContentResult content;
+                ResponseHeaders responseHeaders;
                 MediaTypeHeaderValue? contentType = resultHttpMessage.Content.Headers.ContentType;
                 Charset charset = CharsetParser.Parse(contentType?.CharSet);
                 rawContent = await resultHttpMessage.Content.ReadAsByteArrayAsync(cancellationToken);
@@ -108,6 +113,7 @@ namespace AMDevIT.Restling.Core
                     // If not, ignore the exception.
                 }             
 
+                responseHeaders = ResponseHeaders.Create(resultHttpMessage.Headers);
                 restRequestResult = new(restRequest,
                                         data,
                                         resultHttpMessage.StatusCode,
@@ -115,7 +121,8 @@ namespace AMDevIT.Restling.Core
                                         rawContent,
                                         contentType?.MediaType,
                                         charset,
-                                        content);
+                                        content,
+                                        responseHeaders);
             }
             else
             {

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/Network/Builders/HttpClientContextBuilder.cs
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/Network/Builders/HttpClientContextBuilder.cs
@@ -218,7 +218,8 @@ namespace AMDevIT.Restling.Core.Network.Builders
                 SocketsHttpHandler socketsHttpHandler = new()
                 {
                     CookieContainer = this.cookieContainer,
-                    UseCookies = true 
+                    UseCookies = true,
+                    AllowAutoRedirect = false
                 };
                 this.httpMessageHandler = socketsHttpHandler;
                 this.disposeHandler = true;

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/Network/ResponseHeaders.cs
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/Network/ResponseHeaders.cs
@@ -1,0 +1,73 @@
+﻿using System.Collections.ObjectModel;
+using System.Net.Http.Headers;
+
+namespace AMDevIT.Restling.Core.Network
+{
+    public class ResponseHeaders
+    {
+        #region Fields
+
+        private static readonly ResponseHeaders empty = new();
+
+        private readonly ReadOnlyDictionary<string, IEnumerable<string>> headers;
+        private readonly string? redirectLocation;
+
+        #endregion
+
+        #region Properties
+
+        public static ResponseHeaders Empty => empty;
+
+        public ReadOnlyDictionary<string, IEnumerable<string>> Headers => this.headers;
+
+        public string? RedirectLocation => this.redirectLocation;
+
+        #endregion
+
+        #region .ctor      
+
+        protected ResponseHeaders()
+        {
+            Dictionary<string, IEnumerable<string>> headers = [];
+            this.headers = new ReadOnlyDictionary<string, IEnumerable<string>>(headers);
+            this.redirectLocation = null;
+        }
+
+        protected ResponseHeaders(HttpResponseHeaders sourceResponseHeaders)
+        {
+            Dictionary<string, IEnumerable<string>> headers = [];
+
+            foreach (KeyValuePair<string, IEnumerable<string>> header in sourceResponseHeaders)
+            {
+                headers.Add(header.Key, header.Value);
+            }
+
+            this.headers = new ReadOnlyDictionary<string, IEnumerable<string>>(headers);
+            this.redirectLocation = sourceResponseHeaders.Location?.ToString();
+        }
+
+        #endregion
+
+        #region Methods
+
+        public static ResponseHeaders Create(HttpResponseHeaders httpResponseMessage)
+        {
+            ResponseHeaders responseHeaders = new(httpResponseMessage);
+            return responseHeaders;
+        }
+
+        public override string ToString()
+        {
+            string headers;
+
+            if (this.headers.Count > 0)
+                headers = string.Join(", ", this.headers.Select(h => $"{h.Key}: {h.Value}"));
+            else
+                headers = "No headers";
+
+            return $"Headers: {headers} - Redirect location: {this.redirectLocation ?? "No redirect location provided"}";
+        }
+
+        #endregion
+    }
+}

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/RestRawRequest.cs
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/RestRawRequest.cs
@@ -1,0 +1,105 @@
+﻿using AMDevIT.Restling.Core.Network;
+
+namespace AMDevIT.Restling.Core
+{
+    public class RestRawRequest
+        : RestRequest
+    {
+        #region Properties
+
+        public string? Content
+        {
+            get;
+            set;
+        }
+
+        public string? AcceptType
+        {
+            get;
+            set;
+        }
+
+        public string? ContentType
+        {
+            get;
+            set;
+        }
+
+        #endregion
+
+        #region .ctor
+
+        public RestRawRequest(string uri, 
+                              HttpMethod method, 
+                              string? customMethod = null) 
+            : base(uri, method, customMethod)
+        {
+        }
+
+        public RestRawRequest(string uri, 
+                              HttpMethod method, 
+                              RequestHeaders headers, 
+                              string? customMethod = null) 
+            : base(uri, method, headers, customMethod)
+        {
+        }
+
+        public RestRawRequest(string uri,
+                              HttpMethod method,
+                              string? content,
+                              string? contentType,
+                              string? customMethod = null)
+            : base(uri, method, customMethod)
+        {
+            this.Content = content;
+            this.ContentType = contentType;
+        }
+
+        public RestRawRequest(string uri,
+                            HttpMethod method,
+                            string? content,
+                            string? customMethod = null)
+          : this(uri, method, content: content, contentType: null, customMethod)
+        {
+        }
+
+        public RestRawRequest(string uri,
+                              HttpMethod method,
+                              string? content,
+                              RequestHeaders headers,
+                              string? customMethod = null)
+            : this(uri, 
+                   method, 
+                   content: content, 
+                   contentType: null, 
+                   headers, 
+                   customMethod)
+        {
+        }
+
+        public RestRawRequest(string uri,
+                              HttpMethod method,
+                              string? content,
+                              string? contentType,
+                              RequestHeaders headers,
+                              string? customMethod = null)
+            : base(uri, method, headers, customMethod)
+        {
+            this.Content = content;
+            this.ContentType = contentType;
+        }
+
+        #endregion
+
+        #region Methods
+
+        public override string ToString()
+        {
+            return $"{base.ToString()} - Content: {this.Content ?? "No content"} " +
+                   $"- ContentType: {this.ContentType ?? "No content type"} " +
+                   $"- Accept Type: {this.AcceptType ?? "No accept type"}";
+        }
+
+        #endregion
+    }
+}

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/RestRequestResult.cs
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/RestRequestResult.cs
@@ -1,5 +1,7 @@
-﻿using AMDevIT.Restling.Core.Text;
+﻿using AMDevIT.Restling.Core.Network;
+using AMDevIT.Restling.Core.Text;
 using System.Net;
+using System.Security.AccessControl;
 
 namespace AMDevIT.Restling.Core
 {
@@ -10,6 +12,7 @@ namespace AMDevIT.Restling.Core
                                    string? contentType,
                                    Charset charset,
                                    RetrievedContentResult? retrievedContent,
+                                   ResponseHeaders responseHeaders,
                                    Exception? exception = null)
     {
         #region Fields
@@ -22,6 +25,7 @@ namespace AMDevIT.Restling.Core
         private readonly byte[]? rawContent = rawContent;
         private readonly RetrievedContentResult? retrievedContent = retrievedContent;
         private readonly Exception? exception = exception;
+        private readonly ResponseHeaders responseHeaders = responseHeaders;
 
         #endregion
 
@@ -37,15 +41,16 @@ namespace AMDevIT.Restling.Core
 
         public string? ContentType => this.contentType;
         public Charset CharSet => this.charSet;
-
         public Exception? Exception => this.exception;
+
+        public ResponseHeaders ResponseHeaders => this.responseHeaders;
 
         #endregion
 
         #region .ctor
 
         public RestRequestResult(RestRequest request, Exception exception)
-            : this(request, null, TimeSpan.Zero, [], null, Charset.UTF8, null, exception)
+            : this(request, null, TimeSpan.Zero, [], null, Charset.UTF8, null, ResponseHeaders.Empty, exception)
         {
 
         }
@@ -59,7 +64,8 @@ namespace AMDevIT.Restling.Core
                  [], 
                  null, 
                  Charset.UTF8, 
-                 null, 
+                 null,
+                 ResponseHeaders.Empty,
                  exception)
         {
         }

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/RestRequestResultOfT.cs
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/RestRequestResultOfT.cs
@@ -1,4 +1,5 @@
-﻿using AMDevIT.Restling.Core.Text;
+﻿using AMDevIT.Restling.Core.Network;
+using AMDevIT.Restling.Core.Text;
 using System.Net;
 
 namespace AMDevIT.Restling.Core
@@ -28,6 +29,7 @@ namespace AMDevIT.Restling.Core
                                  string? contentType,
                                  Charset charset,
                                  RetrievedContentResult? retrievedContent,
+                                 ResponseHeaders responseHeaders,
                                  Exception? exception = null) 
             : base(request,
                    statusCode, 
@@ -35,7 +37,8 @@ namespace AMDevIT.Restling.Core
                    rawContent, 
                    contentType,
                    charset,
-                   retrievedContent, 
+                   retrievedContent,                   
+                   responseHeaders,
                    exception)
         {
             this.data = data;

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/RestlingClient.cs
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Core/RestlingClient.cs
@@ -155,6 +155,16 @@ namespace AMDevIT.Restling.Core
             }
 
             restRequestResult = await httpResponseParser.DecodeAsync(resultHttpMessage, restRequest, elapsed, cancellationToken);
+
+            try
+            {
+                resultHttpMessage?.Dispose();
+            }
+            catch(Exception exc)
+            {
+                this.Logger?.LogTrace("Cannot dispose the HttpResponseMessage instance: {exc}", exc.Message);
+            }
+
             return restRequestResult;
         }
 
@@ -244,6 +254,16 @@ namespace AMDevIT.Restling.Core
                                                                         elapsed,
                                                                         payloadJsonSerializerLibrary: restRequest.ForcePayloadJsonSerializerLibrary ?? this.SelectedDefaultSerializationLibrary,
                                                                         cancellationToken);
+
+            try
+            {
+                resultHttpMessage?.Dispose();
+            }
+            catch (Exception exc)
+            {
+                this.Logger?.LogTrace("Cannot dispose the HttpResponseMessage instance: {exc}", exc.Message);
+            }
+
             return restRequestResult;
         }
 
@@ -304,6 +324,16 @@ namespace AMDevIT.Restling.Core
                                                                      restRequest, 
                                                                      elapsed, 
                                                                      cancellationToken);
+
+            try
+            {
+                resultHttpMessage?.Dispose();
+            }
+            catch (Exception exc)
+            {
+                this.Logger?.LogTrace("Cannot dispose the HttpResponseMessage instance: {exc}", exc.Message);
+            }
+
             return restRequestResult;
         }
 
@@ -361,6 +391,16 @@ namespace AMDevIT.Restling.Core
                                                                         elapsed,
                                                                         payloadJsonSerializerLibrary: restRequest.ForcePayloadJsonSerializerLibrary ?? this.SelectedDefaultSerializationLibrary,
                                                                         cancellationToken: cancellationToken);
+
+            try
+            {
+                resultHttpMessage?.Dispose();
+            }
+            catch (Exception exc)
+            {
+                this.Logger?.LogTrace("Cannot dispose the HttpResponseMessage instance: {exc}", exc.Message);
+            }
+
             return restRequestResult;
         }
 
@@ -450,6 +490,16 @@ namespace AMDevIT.Restling.Core
             }
 
             restRequestResult = await httpResponseParser.DecodeAsync(resultHttpMessage, restRequest, elapsed, cancellationToken);
+
+            try
+            {
+                resultHttpMessage?.Dispose();
+            }
+            catch (Exception exc)
+            {
+                this.Logger?.LogTrace("Cannot dispose the HttpResponseMessage instance: {exc}", exc.Message);
+            }
+
             return restRequestResult;
         }
 
@@ -506,6 +556,16 @@ namespace AMDevIT.Restling.Core
                                                                         elapsed,
                                                                         payloadJsonSerializerLibrary: restRequest.ForcePayloadJsonSerializerLibrary ?? this.SelectedDefaultSerializationLibrary,
                                                                         cancellationToken);
+
+            try
+            {
+                resultHttpMessage?.Dispose();
+            }
+            catch (Exception exc)
+            {
+                this.Logger?.LogTrace("Cannot dispose the HttpResponseMessage instance: {exc}", exc.Message);
+            }
+
             return restRequestResult;
         }
 
@@ -591,6 +651,16 @@ namespace AMDevIT.Restling.Core
                 elapsed = stopwatch.Elapsed;
             }
             restRequestResult = await httpResponseParser.DecodeAsync(resultHttpMessage, restRequest, elapsed, cancellationToken);
+
+            try
+            {
+                resultHttpMessage?.Dispose();
+            }
+            catch (Exception exc)
+            {
+                this.Logger?.LogTrace("Cannot dispose the HttpResponseMessage instance: {exc}", exc.Message);
+            }
+
             return restRequestResult;
         }
 
@@ -641,6 +711,16 @@ namespace AMDevIT.Restling.Core
                                                                         elapsed,
                                                                         payloadJsonSerializerLibrary: restRequest.ForcePayloadJsonSerializerLibrary ?? this.SelectedDefaultSerializationLibrary,
                                                                         cancellationToken);
+
+            try
+            {
+                resultHttpMessage?.Dispose();
+            }
+            catch (Exception exc)
+            {
+                this.Logger?.LogTrace("Cannot dispose the HttpResponseMessage instance: {exc}", exc.Message);
+            }
+
             return restRequestResult;
         }
 
@@ -718,11 +798,13 @@ namespace AMDevIT.Restling.Core
                         ArgumentNullException.ThrowIfNull(restRequest, nameof(restRequest));
                         ArgumentException.ThrowIfNullOrWhiteSpace(restRequest.Uri, nameof(restRequest.Uri));
 
-                        httpRequest = BuildHttpRequestMessage(restRequest);
-                        restRequestResult = await this.ExecuteRequestInternalAsync(restRequest,
-                                                                                   httpRequest,
-                                                                                   throwOnGenerics: throwOnGenerics,
-                                                                                   cancellationToken: cancellationToken);
+                        using (httpRequest = BuildHttpRequestMessage(restRequest))
+                        {
+                            restRequestResult = await this.ExecuteRequestInternalAsync(restRequest,
+                                                                                       httpRequest,
+                                                                                       throwOnGenerics: throwOnGenerics,
+                                                                                       cancellationToken: cancellationToken);
+                        }
                         break;
                     }
             }
@@ -770,7 +852,6 @@ namespace AMDevIT.Restling.Core
                 case RestRawRequest restRawRequest:
                     {
                         restRequestResult = await this.ExecuteRawRequestAsync<T>(restRawRequest, 
-                                                                                 throwOnGenerics, 
                                                                                  cancellationToken);
                     }
                     break;
@@ -786,11 +867,13 @@ namespace AMDevIT.Restling.Core
                         //if (restRequest.GetType().IsGenericType == true)
                         //    throw new InvalidOperationException("The rest request contains generic type data. Cannot be executed with using a call without payload.");
 
-                        httpRequest = this.BuildHttpRequestMessage(restRequest);
-                        restRequestResult = await this.ExecuteRequestInternalAsync<T>(restRequest,
-                                                                                      httpRequest,
-                                                                                      throwOnGenerics: throwOnGenerics,
-                                                                                      cancellationToken);
+                        using (httpRequest = this.BuildHttpRequestMessage(restRequest))
+                        {
+                            restRequestResult = await this.ExecuteRequestInternalAsync<T>(restRequest,
+                                                                                          httpRequest,
+                                                                                          throwOnGenerics: throwOnGenerics,
+                                                                                          cancellationToken);
+                        }
                     }
                     break;
             }
@@ -820,11 +903,13 @@ namespace AMDevIT.Restling.Core
             ArgumentNullException.ThrowIfNull(restRequest, nameof(restRequest));
             ArgumentException.ThrowIfNullOrWhiteSpace(restRequest.Uri, nameof(restRequest.Uri));
 
-            httpRequest = this.BuildHttpRequestMessageWithPayload<T>(restRequest);
-            restRequestResult = await this.ExecuteRequestInternalAsync<D>(restRequest, 
-                                                                          httpRequest, 
-                                                                          throwOnGenerics: throwOnGenerics, 
-                                                                          cancellationToken: cancellationToken);
+            using (httpRequest = this.BuildHttpRequestMessageWithPayload<T>(restRequest))
+            {
+                restRequestResult = await this.ExecuteRequestInternalAsync<D>(restRequest,
+                                                                              httpRequest,
+                                                                              throwOnGenerics: throwOnGenerics,
+                                                                              cancellationToken: cancellationToken);
+            }
             return restRequestResult;
         }
 
@@ -838,32 +923,53 @@ namespace AMDevIT.Restling.Core
             TimeSpan elapsed;
             HttpRequestMessage httpRequest;
 
-            httpRequest = this.BuildHttpRequestMessage(formUrlEncodedRequest);
-            httpRequest.Content = this.BuildFormUrlEncodedContent(formUrlEncodedRequest.Parameters);
+            using (httpRequest = this.BuildHttpRequestMessage(formUrlEncodedRequest))
+            {
+                httpRequest.Content = this.BuildFormUrlEncodedContent(formUrlEncodedRequest.Parameters);
 
-            try
-            {
-                stopwatch = Stopwatch.StartNew();
-                resultHttpMessage = await this.httpClientContext.HttpClient.SendAsync(httpRequest, cancellationToken);
-                stopwatch.Stop();
-            }
-            catch (Exception exc)
-            {
-                if (stopwatch.IsRunning)
+                try
+                {
+                    stopwatch = Stopwatch.StartNew();
+                    resultHttpMessage = await this.httpClientContext.HttpClient.SendAsync(httpRequest, cancellationToken);
                     stopwatch.Stop();
+                }
+                catch (Exception exc)
+                {
+                    if (stopwatch.IsRunning)
+                        stopwatch.Stop();
 
-                this.Logger?.LogError(exc, "Cannot execute {method} REST request.", httpRequest.Method.Method);
-                return new (formUrlEncodedRequest, exc, stopwatch.Elapsed);
-            }
-            finally
-            {
-                elapsed = stopwatch.Elapsed;
+                    this.Logger?.LogError(exc, "Cannot execute {method} REST request.", httpRequest.Method.Method);
+
+                    try
+                    {
+                        resultHttpMessage?.Dispose();
+                    }
+                    catch (Exception disposeExc)
+                    {
+                        this.Logger?.LogTrace(disposeExc, "Cannot dispose the HttpResponseMessage instance: {exc}", exc.Message);
+                    }
+
+                    return new(formUrlEncodedRequest, exc, stopwatch.Elapsed);
+                }
+                finally
+                {
+                    elapsed = stopwatch.Elapsed;
+                }
+
+                restRequestResult = await httpResponseParser.DecodeAsync(resultHttpMessage,
+                                                                         formUrlEncodedRequest,
+                                                                         elapsed,
+                                                                         cancellationToken);
+                try
+                {
+                    resultHttpMessage?.Dispose();
+                }
+                catch (Exception exc)
+                {
+                    this.Logger?.LogTrace(exc, "Cannot dispose the HttpResponseMessage instance: {exc}", exc.Message);
+                }
             }
 
-            restRequestResult = await httpResponseParser.DecodeAsync(resultHttpMessage,
-                                                                     formUrlEncodedRequest,
-                                                                     elapsed,
-                                                                     cancellationToken);
             return restRequestResult;
         }
 
@@ -877,33 +983,55 @@ namespace AMDevIT.Restling.Core
             TimeSpan elapsed;
             HttpRequestMessage httpRequest;
 
-            httpRequest = this.BuildHttpRequestMessage(formUrlEncodedRequest);
-            httpRequest.Content = this.BuildFormUrlEncodedContent(formUrlEncodedRequest.Parameters);
+            using (httpRequest = this.BuildHttpRequestMessage(formUrlEncodedRequest))
+            {
+                httpRequest.Content = this.BuildFormUrlEncodedContent(formUrlEncodedRequest.Parameters);
 
-            try
-            {
-                stopwatch = Stopwatch.StartNew();
-                resultHttpMessage = await this.httpClientContext.HttpClient.SendAsync(httpRequest, cancellationToken);
-                stopwatch.Stop();
-            }
-            catch (Exception exc)
-            {
-                if (stopwatch.IsRunning)
+                try
+                {
+                    stopwatch = Stopwatch.StartNew();
+                    resultHttpMessage = await this.httpClientContext.HttpClient.SendAsync(httpRequest, cancellationToken);
                     stopwatch.Stop();
+                }
+                catch (Exception exc)
+                {
+                    if (stopwatch.IsRunning)
+                        stopwatch.Stop();
 
-                this.Logger?.LogError(exc, "Cannot execute {method} REST request.", httpRequest.Method.Method);
-                return new(formUrlEncodedRequest, exc, stopwatch.Elapsed);
-            }
-            finally
-            {
-                elapsed = stopwatch.Elapsed;
+                    this.Logger?.LogError(exc, "Cannot execute {method} REST request.", httpRequest.Method.Method);
+
+                    try
+                    {
+                        resultHttpMessage?.Dispose();
+                    }
+                    catch (Exception disposeExc)
+                    {
+                        this.Logger?.LogTrace(disposeExc, "Cannot dispose the HttpResponseMessage instance: {exc}", exc.Message);
+                    }
+
+                    return new(formUrlEncodedRequest, exc, stopwatch.Elapsed);
+                }
+                finally
+                {
+                    elapsed = stopwatch.Elapsed;
+                }
+
+                restRequestResult = await httpResponseParser.DecodeAsync<T>(resultHttpMessage,
+                                                                            formUrlEncodedRequest,
+                                                                            elapsed,
+                                                                            formUrlEncodedRequest.ForcePayloadJsonSerializerLibrary,
+                                                                            cancellationToken);
+
+                try
+                {
+                    resultHttpMessage?.Dispose();
+                }
+                catch (Exception exc)
+                {
+                    this.Logger?.LogTrace("Cannot dispose the HttpResponseMessage instance: {exc}", exc.Message);
+                }
             }
 
-            restRequestResult = await httpResponseParser.DecodeAsync<T>(resultHttpMessage, 
-                                                                        formUrlEncodedRequest, 
-                                                                        elapsed, 
-                                                                        formUrlEncodedRequest.ForcePayloadJsonSerializerLibrary, 
-                                                                        cancellationToken);
             return restRequestResult;
         }
 
@@ -916,36 +1044,57 @@ namespace AMDevIT.Restling.Core
             Stopwatch stopwatch = new();
             TimeSpan elapsed;
             HttpRequestMessage httpRequest;
-            
-            httpRequest = this.BuildHttpRequestMessage(restRawRequest);
-            httpRequest.Content = this.BuildRawHttpContent(restRawRequest.Content,
-                                                           restRawRequest.ContentType);
 
-            try
+            using (httpRequest = this.BuildHttpRequestMessage(restRawRequest))
             {
-                stopwatch = Stopwatch.StartNew();
-                resultHttpMessage = await this.httpClientContext.HttpClient.SendAsync(httpRequest, cancellationToken);
-                stopwatch.Stop();
-            }
-            catch (Exception exc)
-            {
-                if (stopwatch.IsRunning)
+                httpRequest.Content = this.BuildRawHttpContent(restRawRequest.Content,
+                                                               restRawRequest.ContentType);
+
+                try
+                {
+                    stopwatch = Stopwatch.StartNew();
+                    resultHttpMessage = await this.httpClientContext.HttpClient.SendAsync(httpRequest, cancellationToken);
                     stopwatch.Stop();
+                }
+                catch (Exception exc)
+                {
+                    if (stopwatch.IsRunning)
+                        stopwatch.Stop();
 
-                this.Logger?.LogError(exc, "Cannot execute {method} REST request.", httpRequest.Method.Method);
-                return new (restRawRequest, exc, stopwatch.Elapsed);
-            }
-            finally
-            {
-                elapsed = stopwatch.Elapsed;
+                    this.Logger?.LogError(exc, "Cannot execute {method} REST request.", httpRequest.Method.Method);
+
+                    try
+                    {
+                        resultHttpMessage?.Dispose();
+                    }
+                    catch (Exception disposeExc)
+                    {
+                        this.Logger?.LogTrace(disposeExc, "Cannot dispose the HttpResponseMessage instance: {exc}", exc.Message);
+                    }
+
+                    return new(restRawRequest, exc, stopwatch.Elapsed);
+                }
+                finally
+                {
+                    elapsed = stopwatch.Elapsed;
+                }
+
+                restRequestResult = await httpResponseParser.DecodeAsync(resultHttpMessage, restRawRequest, elapsed, cancellationToken);
+
+                try
+                {
+                    resultHttpMessage?.Dispose();
+                }
+                catch (Exception exc)
+                {
+                    this.Logger?.LogTrace("Cannot dispose the HttpResponseMessage instance: {exc}", exc.Message);
+                }
             }
 
-            restRequestResult = await httpResponseParser.DecodeAsync(resultHttpMessage, restRawRequest, elapsed, cancellationToken);
             return restRequestResult;
         }
 
         public async Task<RestRequestResult<T>> ExecuteRawRequestAsync<T>(RestRawRequest restRawRequest,
-                                                                          bool throwOnGenerics = false,
                                                                           CancellationToken cancellationToken = default)
         {
             HttpResponseParser httpResponseParser = new(this.Logger);
@@ -955,34 +1104,56 @@ namespace AMDevIT.Restling.Core
             TimeSpan elapsed;
             HttpRequestMessage httpRequest;
 
-            httpRequest = this.BuildHttpRequestMessage(restRawRequest);
-            httpRequest.Content = this.BuildRawHttpContent(restRawRequest.Content, 
-                                                           restRawRequest.ContentType); 
+            using (httpRequest = this.BuildHttpRequestMessage(restRawRequest))
+            {
+                httpRequest.Content = this.BuildRawHttpContent(restRawRequest.Content,
+                                                               restRawRequest.ContentType);
 
-            try
-            {
-                stopwatch = Stopwatch.StartNew();
-                resultHttpMessage = await this.httpClientContext.HttpClient.SendAsync(httpRequest, cancellationToken);
-                stopwatch.Stop();
-            }
-            catch (Exception exc)
-            {
-                if (stopwatch.IsRunning)
+                try
+                {
+                    stopwatch = Stopwatch.StartNew();
+                    resultHttpMessage = await this.httpClientContext.HttpClient.SendAsync(httpRequest, cancellationToken);
                     stopwatch.Stop();
+                }
+                catch (Exception exc)
+                {
+                    if (stopwatch.IsRunning)
+                        stopwatch.Stop();
 
-                this.Logger?.LogError(exc, "Cannot execute {method} REST request.", httpRequest.Method.Method);
-                return new (restRawRequest, exc, stopwatch.Elapsed);
-            }
-            finally
-            {
-                elapsed = stopwatch.Elapsed;
+                    this.Logger?.LogError(exc, "Cannot execute {method} REST request.", httpRequest.Method.Method);
+
+                    try
+                    {
+                        resultHttpMessage?.Dispose();
+                    }
+                    catch (Exception disposeExc)
+                    {
+                        this.Logger?.LogTrace(disposeExc, "Cannot dispose the HttpResponseMessage instance: {exc}", exc.Message);
+                    }
+
+                    return new(restRawRequest, exc, stopwatch.Elapsed);
+                }
+                finally
+                {
+                    elapsed = stopwatch.Elapsed;
+                }
+
+                restRequestResult = await httpResponseParser.DecodeAsync<T>(resultHttpMessage,
+                                                                            restRawRequest,
+                                                                            elapsed,
+                                                                            restRawRequest.ForcePayloadJsonSerializerLibrary,
+                                                                            cancellationToken);
+
+                try
+                {
+                    resultHttpMessage?.Dispose();
+                }
+                catch (Exception exc)
+                {
+                    this.Logger?.LogTrace("Cannot dispose the HttpResponseMessage instance: {exc}", exc.Message);
+                }
             }
 
-            restRequestResult = await httpResponseParser.DecodeAsync<T>(resultHttpMessage, 
-                                                                        restRawRequest, 
-                                                                        elapsed, 
-                                                                        restRawRequest.ForcePayloadJsonSerializerLibrary,
-                                                                        cancellationToken);
             return restRequestResult;
         }
 
@@ -1027,6 +1198,16 @@ namespace AMDevIT.Restling.Core
                     stopwatch.Stop();
 
                 this.Logger?.LogError(exc, "Cannot execute {method} REST request.", httpRequest.Method.Method);
+
+                try
+                {
+                    resultHttpMessage?.Dispose();
+                }
+                catch (Exception disposeExc)
+                {
+                    this.Logger?.LogTrace(disposeExc, "Cannot dispose the HttpResponseMessage instance: {exc}", exc.Message);
+                }
+
                 return new RestRequestResult(restRequest, exc, stopwatch.Elapsed);
             }
             finally
@@ -1034,7 +1215,17 @@ namespace AMDevIT.Restling.Core
                 elapsed = stopwatch.Elapsed;
             }
 
-            restRequestResult = await httpResponseParser.DecodeAsync(resultHttpMessage, restRequest, elapsed, cancellationToken);
+            restRequestResult = await httpResponseParser.DecodeAsync(resultHttpMessage, restRequest, elapsed, cancellationToken);            
+
+            try
+            {
+                resultHttpMessage?.Dispose();
+            }
+            catch (Exception exc)
+            {
+                this.Logger?.LogTrace("Cannot dispose the HttpResponseMessage instance: {exc}", exc.Message);
+            }
+
             return restRequestResult;
         }
 
@@ -1072,6 +1263,15 @@ namespace AMDevIT.Restling.Core
                 if (stopwatch.IsRunning)
                     stopwatch.Stop();
 
+                try
+                {
+                    resultHttpMessage?.Dispose();
+                }
+                catch (Exception disposeExc)
+                {
+                    this.Logger?.LogTrace(disposeExc, "Cannot dispose the HttpResponseMessage instance: {exc}", exc.Message);
+                }
+
                 this.Logger?.LogError(exc, "Cannot execute {method} REST request.", httpRequest.Method.Method);
                 return new RestRequestResult<T>(restRequest, exc, stopwatch.Elapsed);
             }
@@ -1085,6 +1285,16 @@ namespace AMDevIT.Restling.Core
                                                                         elapsed, 
                                                                         payloadJsonSerializerLibrary: restRequest.ForcePayloadJsonSerializerLibrary, 
                                                                         cancellationToken);
+
+            try
+            {
+                resultHttpMessage?.Dispose();
+            }
+            catch (Exception exc)
+            {
+                this.Logger?.LogTrace("Cannot dispose the HttpResponseMessage instance: {exc}", exc.Message);
+            }
+
             return restRequestResult;
         }
 

--- a/Sources/AMDevIT.Restling/AMDevIT.Restling.Tests/RestClientTests.cs
+++ b/Sources/AMDevIT.Restling/AMDevIT.Restling.Tests/RestClientTests.cs
@@ -11,6 +11,7 @@ using AMDevIT.Restling.Tests.Models.ST;
 using AMDevIT.Restling.Tests.Models.Xml;
 using Microsoft.Extensions.Logging;
 using System.Diagnostics;
+using System.Reflection.Metadata;
 
 namespace AMDevIT.Restling.Tests
 {
@@ -45,6 +46,28 @@ namespace AMDevIT.Restling.Tests
         }
 
         #region Quick methods
+
+        [TestMethod]
+        [DataRow("https://httpbin.org/headers", "Bearer", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1dG50IjoiR3Jhc3NlcyBkaSBjYXpvIHRyYWZmZW8iLCJzdWJfY2VyaWFsIjoiU0hBREVPV19XRUxMRU5EIiwiZXhwIjoxNzAwMDAwMDAwLCJwZXJlY2hpIiOiJOdWFsbG9zIFNwYWdoZXR0aSIsImxldmVsIjoxMiwiaXNfcmVhbCI6ZmFsc2V9.XtQp-jYVaH5x9JZHKjG4dpK_Bj1E6dDcKzOYd5TxaVQ")]
+        public async Task TestHttpHeaders(string uri, string authScheme, string authHeaderValue)
+        {
+            CancellationToken cancellationToken = this.TestContext.CancellationTokenSource.Token;
+            RestlingClient restlingClient = new(this.Logger);
+            RestRequestResult<STHttpBinResponse> stRestRequestResult;
+            AuthenticationHeader authenticationHeader = new (authScheme, authHeaderValue);
+            RequestHeaders requestHeaders = new(authenticationHeader);
+            STHttpBinResponse? stsHttpBinResponse;
+
+            stRestRequestResult = await restlingClient.GetAsync<STHttpBinResponse>(uri,
+                                                                                   requestHeaders,
+                                                                                   cancellationToken: cancellationToken);
+
+            Assert.IsNotNull(stRestRequestResult.Data, "Rest response data for Newtonsoft is null");
+
+            stsHttpBinResponse = stRestRequestResult.Data;
+            Trace.WriteLine("St response:");
+            Trace.WriteLine(stsHttpBinResponse.ToString());
+        }
 
         [TestMethod]
         [DataRow("https://httpbin.org/get", "1234")]


### PR DESCRIPTION
Added support for raw calls with text/plain or customized media type, and for form encoded calls. Also, Restling now doesn't follow automatically redirect by default, allowing to use retry patterns to follow redirects with an authentication header set.